### PR TITLE
Fix Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@ README.md
 LICENSE
 docs/
 .vscode/
+Dockerfile
+.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.gitignore
+README.md
+LICENSE
+docs/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:20-alpine
 
 ENV NODE_ENV=production
-ARG NPM_BUILD="npm install --omit=dev"
 EXPOSE 8080/tcp
 
 LABEL maintainer="Holy WebWork"
@@ -10,10 +9,14 @@ LABEL description="Example application of Holy Unblocker's frontend which can be
 
 WORKDIR /app
 
-COPY ["package.json", "package-lock.json", "./"]
-RUN $NPM_BUILD
-
 COPY . .
+COPY ./config/config.example.js ./config/config.js
+
+RUN sed -i 's/host: \"localhost\"/host: \"0.0.0.0\"/g' ./config/config.js
+
+RUN apk add --upgrade --no-cache python3 make g++
+RUN npm install
+RUN npm run build
 
 ENTRYPOINT [ "node" ]
 CMD ["run-server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,17 @@
 services:
-  ultraviolet:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile
-      args:
-        - NPM_BUILD=npm ci --omit=dev --frozen-lockfile
+  holy-unblocker:
+    image: diffusehyperion/holy-unblocker
+    container_name: holy-unblocker
+    restart: unless-stopped
     ports:
       - "8080:8080"
+    volumes:
+      - holy-unblocker-config:/app/config
+
+volumes:
+  holy-unblocker-config:
+    name: holy-unblocker-config
+    
+networks:
+  default:
+    name: holy-unblocker


### PR DESCRIPTION
Currently, the Dockerfile doesn't work. This should make it functional again. The image automatically copies the default config and changes the host from localhost to 0.0.0.0 so that the host can reach the service. Did this because otherwise the container would also need to have caddy running on it and it would be cursed af lol

The docker-compose.yml included uses my image, you might want to change it to yours once you have your own ci setup, I'm using github actions to build my images [here](https://github.com/DiffuseHyperion/holy-unblocker-docker/blob/master/.github/workflows/docker-image.yml), if you want to copy it.